### PR TITLE
Detailed and Summarized Views for Inspect Page

### DIFF
--- a/src/gui/components/types/mod.rs
+++ b/src/gui/components/types/mod.rs
@@ -1,1 +1,2 @@
 pub mod my_modal;
+pub mod report_view;

--- a/src/gui/components/types/report_view.rs
+++ b/src/gui/components/types/report_view.rs
@@ -1,0 +1,19 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReportView {
+    Detailed,
+    Summarized,
+}
+
+// impl ReportView{
+//     fn update(&mut self, message: Message) {
+//         match message {
+//             Message::ToggleReportView => {
+//                 *self = match self {
+//                     ReportView::Detailed => ReportView::Summarized,
+//                     ReportView::Summarized => ReportView::Detailed,
+//                 };
+//             }
+//             _ => {}
+//         }
+//     }
+// }

--- a/src/gui/types/message.rs
+++ b/src/gui/types/message.rs
@@ -89,4 +89,6 @@ pub enum Message {
     FontLoaded(Result<(), font::Error>),
     /// Enable or disable gradients
     GradientsSelection(GradientType),
+
+    ToggleReportView,
 }

--- a/src/gui/types/sniffer.rs
+++ b/src/gui/types/sniffer.rs
@@ -11,6 +11,8 @@ use pcap::Device;
 
 use crate::chart::manage_chart_data::update_charts_data;
 use crate::gui::components::types::my_modal::MyModal;
+use crate::gui::components::types::report_view::ReportView;
+
 use crate::gui::pages::types::running_page::RunningPage;
 use crate::gui::pages::types::settings_page::SettingsPage;
 use crate::gui::styles::types::gradient_type::GradientType;
@@ -67,6 +69,8 @@ pub struct Sniffer {
     pub report_sort_type: ReportSortType,
     /// Currently displayed modal; None if no modal is displayed
     pub modal: Option<MyModal>,
+    /// Currently displayed report view(detailed or summarized)
+    pub report_view: ReportView,
     /// Currently displayed settings page; None if settings is closed
     pub settings_page: Option<SettingsPage>,
     /// Remembers the last opened setting page
@@ -113,6 +117,7 @@ impl Sniffer {
             waiting: ".".to_string(),
             traffic_chart: TrafficChart::new(config_settings.style, config_settings.language),
             report_sort_type: ReportSortType::MostRecent,
+            report_view: ReportView::Detailed,
             modal: None,
             settings_page: None,
             last_opened_setting: SettingsPage::Notifications,
@@ -129,6 +134,13 @@ impl Sniffer {
 
     pub fn update(&mut self, message: Message) -> Command<Message> {
         match message {
+            Message::ToggleReportView => {
+                if self.report_view.eq(&ReportView::Detailed) {
+                    self.report_view = ReportView::Summarized;
+                } else {
+                    self.report_view = ReportView::Detailed;
+                }
+            }
             Message::TickRun => return self.refresh_data(),
             Message::AdapterSelection(name) => self.set_adapter(&name),
             Message::IpVersionSelection(version) => self.filters.ip = version,

--- a/src/networking/manage_packets.rs
+++ b/src/networking/manage_packets.rs
@@ -447,7 +447,7 @@ pub fn is_my_address(address_to_lookup: &String, my_interface_addresses: &Vec<Ad
 pub fn get_capture_result(device: &MyDevice) -> (Option<String>, Option<Capture<Active>>) {
     let cap_result = Capture::from_device(&*device.name)
         .expect("Capture initialization error\n\r")
-        .promisc(true)
+        .promisc(false)
         .snaplen(256) //limit stored packets slice dimension (to keep more in the buffer)
         .immediate_mode(true) //parse packets ASAP!
         .open();


### PR DESCRIPTION
I defined two views for inspect page. One is detailed, which is basically the original view, with 2 added columns, uid and pid. The other view is for processes, where each process's total packets and bytes are aggregated and shown along with the pid. 